### PR TITLE
Add Recorder and prometheus implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+go:
+  - "1.12"
+
+env:
+  - GO111MODULE=on
+
+script:
+  - make ci

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+## 0.x.x / 2019-xx-xx
+
+* [FEATURE] Add Prometheus recorder.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+
+UNIT_TEST_CMD := go test `go list ./... | grep -v vendor` -race -v
+INTEGRATION_TEST_CMD := go test `go list ./... | grep -v vendor`  -race -v -tags='integration'
+BENCHMARK_CMD := go test -benchmem -bench=.
+DEPS_CMD := GO111MODULE=on go mod tidy && GO111MODULE=on go mod vendor
+
+.PHONY: default
+default: test
+
+.PHONY: unit-test
+unit-test:
+	$(UNIT_TEST_CMD)
+.PHONY: integration-test
+integration-test:
+	$(INTEGRATION_TEST_CMD)
+.PHONY: test
+test: integration-test
+
+.PHONY: benchmark
+benchmark:
+	$(BENCHMARK_CMD)
+
+.PHONY: ci
+ci: test
+
+.PHONY: deps
+deps:
+	$(DEPS_CMD)
+
+.PHONY: godoc
+godoc: 
+	godoc -http=":6060"

--- a/go.mod
+++ b/go.mod
@@ -1,2 +1,6 @@
 module github.com/slok/go-http-metrics
 
+require (
+	github.com/prometheus/client_golang v0.9.2
+	github.com/stretchr/testify v1.2.2
+)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"time"
+)
+
+// Recorder knows how to record and measure the metrics. This
+// Interface has the required methods to be used with the HTTP
+// middlewares.
+type Recorder interface {
+	// ObserveHTTPRequestDuration measures the duration of an HTTP request.
+	ObserveHTTPRequestDuration(id string, duration time.Duration, method, code string)
+}
+
+// Dummy is a dummy recorder.
+var Dummy = &dummy{}
+
+type dummy struct{}
+
+func (dummy) ObserveHTTPRequestDuration(id string, duration time.Duration, method, code string) {}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -1,0 +1,67 @@
+package prometheus
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/slok/go-http-metrics/metrics"
+)
+
+// Config has the dependencies and values of the recorder.
+type Config struct {
+	// Prefix is the prefix that will be set on the metrics, by default it will be empty.
+	Prefix string
+	// DurationBuckets are the buckets used by Prometheus for the HTTP request duration metrics,
+	// by default uses Prometheus default buckets (from 5ms to 10s).
+	DurationBuckets []float64
+	// Registry is the registry that ill be used by the recorder to store the metrics,
+	// if the default registry is not used then it will use the default one.
+	Registry prometheus.Registerer
+}
+
+func (c *Config) defaults() {
+	if len(c.DurationBuckets) == 0 {
+		c.DurationBuckets = prometheus.DefBuckets
+	}
+
+	if c.Registry == nil {
+		c.Registry = prometheus.DefaultRegisterer
+	}
+}
+
+type recorder struct {
+	httpRequestHistogram *prometheus.HistogramVec
+
+	cfg Config
+}
+
+// New returns a new metrics recorder that implements the recorder
+// using Prometheus as the backend.
+func New(cfg Config) metrics.Recorder {
+	cfg.defaults()
+
+	r := &recorder{
+		httpRequestHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: cfg.Prefix,
+			Subsystem: "http",
+			Name:      "request_duration_seconds",
+			Help:      "The latency of the HTTP requests.",
+			Buckets:   cfg.DurationBuckets,
+		}, []string{"handler", "method", "code"}),
+
+		cfg: cfg,
+	}
+
+	r.registerMetrics()
+
+	return r
+}
+
+func (r recorder) registerMetrics() {
+	r.cfg.Registry.MustRegister(r.httpRequestHistogram)
+}
+
+func (r recorder) ObserveHTTPRequestDuration(id string, duration time.Duration, method, code string) {
+	r.httpRequestHistogram.WithLabelValues(id, method, code).Observe(duration.Seconds())
+}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1,0 +1,155 @@
+package prometheus_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/slok/go-http-metrics/metrics"
+	libprometheus "github.com/slok/go-http-metrics/metrics/prometheus"
+)
+
+func TestPrometheusRecorder(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        libprometheus.Config
+		recordMetrics func(r metrics.Recorder)
+		expMetrics    []string
+	}{
+		{
+			name:   "Default configuration should measure with the default metric style.",
+			config: libprometheus.Config{},
+			recordMetrics: func(r metrics.Recorder) {
+				r.ObserveHTTPRequestDuration("test1", 5*time.Second, http.MethodGet, "200")
+				r.ObserveHTTPRequestDuration("test1", 175*time.Millisecond, http.MethodGet, "200")
+				r.ObserveHTTPRequestDuration("test2", 50*time.Millisecond, http.MethodGet, "201")
+				r.ObserveHTTPRequestDuration("test3", 700*time.Millisecond, http.MethodPost, "500")
+			},
+			expMetrics: []string{
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.005"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.01"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.025"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.05"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.1"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.25"} 1`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.5"} 1`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="1"} 1`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="2.5"} 1`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="5"} 2`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="10"} 2`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="+Inf"} 2`,
+				`http_request_duration_seconds_count{code="200",handler="test1",method="GET"} 2`,
+
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="0.005"} 0`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="0.01"} 0`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="0.025"} 0`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="0.05"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="0.1"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="0.25"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="0.5"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="1"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="2.5"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="5"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="10"} 1`,
+				`http_request_duration_seconds_bucket{code="201",handler="test2",method="GET",le="+Inf"} 1`,
+				`http_request_duration_seconds_count{code="201",handler="test2",method="GET"} 1`,
+
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="0.005"} 0`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="0.01"} 0`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="0.025"} 0`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="0.05"} 0`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="0.1"} 0`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="0.25"} 0`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="0.5"} 0`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="1"} 1`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="2.5"} 1`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="5"} 1`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="10"} 1`,
+				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="+Inf"} 1`,
+				`http_request_duration_seconds_count{code="500",handler="test3",method="POST"} 1`,
+			},
+		},
+		{
+			name: "Using a prefix in the configuration should measure with prefix.",
+			config: libprometheus.Config{
+				Prefix: "batman",
+			},
+			recordMetrics: func(r metrics.Recorder) {
+				r.ObserveHTTPRequestDuration("test1", 5*time.Second, http.MethodGet, "200")
+				r.ObserveHTTPRequestDuration("test1", 175*time.Millisecond, http.MethodGet, "200")
+			},
+			expMetrics: []string{
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.005"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.01"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.025"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.05"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.1"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.25"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.5"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="1"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="2.5"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="5"} 2`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="10"} 2`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="+Inf"} 2`,
+				`batman_http_request_duration_seconds_count{code="200",handler="test1",method="GET"} 2`,
+			},
+		},
+				{
+			name: "Using custom buckets in the configuration should measure with custom buckets.",
+			config: libprometheus.Config{
+				Prefix: "batman",
+			},
+			recordMetrics: func(r metrics.Recorder) {
+				r.ObserveHTTPRequestDuration("test1", 5*time.Second, http.MethodGet, "200")
+				r.ObserveHTTPRequestDuration("test1", 175*time.Millisecond, http.MethodGet, "200")
+			},
+			expMetrics: []string{
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.005"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.01"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.025"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.05"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.1"} 0`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.25"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.5"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="1"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="2.5"} 1`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="5"} 2`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="10"} 2`,
+				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="+Inf"} 2`,
+				`batman_http_request_duration_seconds_count{code="200",handler="test1",method="GET"} 2`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			reg := prometheus.NewRegistry()
+			test.config.Registry = reg
+			mrecorder := libprometheus.New(test.config)
+			test.recordMetrics(mrecorder)
+
+			// Get the metrics handler and serve.
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/metrics", nil)
+			promhttp.HandlerFor(reg, promhttp.HandlerOpts{}).ServeHTTP(rec, req)
+
+			resp := rec.Result()
+
+			// Check all metrics are present.
+			if assert.Equal(http.StatusOK, resp.StatusCode) {
+				body, _ := ioutil.ReadAll(resp.Body)
+				for _, expMetric := range test.expMetrics {
+					assert.Contains(string(body), expMetric, "metric not present on the result")
+				}
+			}
+		})
+	}
+}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -100,29 +100,29 @@ func TestPrometheusRecorder(t *testing.T) {
 				`batman_http_request_duration_seconds_count{code="200",handler="test1",method="GET"} 2`,
 			},
 		},
-				{
+		{
 			name: "Using custom buckets in the configuration should measure with custom buckets.",
 			config: libprometheus.Config{
-				Prefix: "batman",
+				DurationBuckets: []float64{1, 2, 10, 20, 50, 200, 500, 1000, 2000, 5000, 10000},
 			},
 			recordMetrics: func(r metrics.Recorder) {
-				r.ObserveHTTPRequestDuration("test1", 5*time.Second, http.MethodGet, "200")
-				r.ObserveHTTPRequestDuration("test1", 175*time.Millisecond, http.MethodGet, "200")
+				r.ObserveHTTPRequestDuration("test1", 75*time.Minute, http.MethodGet, "200")
+				r.ObserveHTTPRequestDuration("test1", 200*time.Hour, http.MethodGet, "200")
 			},
 			expMetrics: []string{
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.005"} 0`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.01"} 0`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.025"} 0`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.05"} 0`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.1"} 0`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.25"} 1`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.5"} 1`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="1"} 1`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="2.5"} 1`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="5"} 2`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="10"} 2`,
-				`batman_http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="+Inf"} 2`,
-				`batman_http_request_duration_seconds_count{code="200",handler="test1",method="GET"} 2`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="1"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="2"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="10"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="20"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="50"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="200"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="500"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="1000"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="2000"} 0`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="5000"} 1`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="10000"} 1`,
+				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="+Inf"} 2`,
+				`http_request_duration_seconds_count{code="200",handler="test1",method="GET"} 2`,
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds the `metrics.Recorder` interface and it'sPprometheus implementation (at this moment ports the functionality from https://github.com/slok/go-prometheus-middleware)