### PR TITLE
Add the ability to customize the label names of the prometheus recorder metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+## 0.x.x / 2019-xx-xx
+
+* [ENHANCEMENT] Make the label names of Prometheus recorder configurable.
+
 ## 0.1.0 / 2019-03-18
 
 * [FEATURE] Add gorestful compatible middleware.

--- a/Readme.md
+++ b/Readme.md
@@ -139,6 +139,10 @@ DurationBuckets are the buckets used for the request duration histogram metric, 
 
 The Prometheus registry to use, by default it will use Prometheus global registry (the default one on Prometheus library).
 
+#### Label names
+
+The label names of the Prometheus metrics can be configured using `HandlerIDLabel`, `StatusCodeLabel`, `MethodLabel`...
+
 ## Benchmarks
 
 ```text

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -18,6 +18,12 @@ type Config struct {
 	// Registry is the registry that will be used by the recorder to store the metrics,
 	// if the default registry is not used then it will use the default one.
 	Registry prometheus.Registerer
+	// HandlerIDLabel is the name that will be set to the handler ID label, by default is `handler`.
+	HandlerIDLabel string
+	// StatusCodeLabel is the name that will be set to the status code label, by default is `code`.
+	StatusCodeLabel string
+	// MethodLabel is the name that will be set to the method label, by default is `method`.
+	MethodLabel string
 }
 
 func (c *Config) defaults() {
@@ -27,6 +33,18 @@ func (c *Config) defaults() {
 
 	if c.Registry == nil {
 		c.Registry = prometheus.DefaultRegisterer
+	}
+
+	if c.HandlerIDLabel == "" {
+		c.HandlerIDLabel = "handler"
+	}
+
+	if c.StatusCodeLabel == "" {
+		c.StatusCodeLabel = "code"
+	}
+
+	if c.MethodLabel == "" {
+		c.MethodLabel = "method"
 	}
 }
 
@@ -48,7 +66,7 @@ func NewRecorder(cfg Config) metrics.Recorder {
 			Name:      "request_duration_seconds",
 			Help:      "The latency of the HTTP requests.",
 			Buckets:   cfg.DurationBuckets,
-		}, []string{"handler", "method", "code"}),
+		}, []string{cfg.HandlerIDLabel, cfg.MethodLabel, cfg.StatusCodeLabel}),
 
 		cfg: cfg,
 	}


### PR DESCRIPTION
Sometimes we need to customize the metrics label to adhere to standards with other teams, groups or due to automation, so instead of using relabelling we could directly configure this settings at the source of the metric.

This PR gives Prometheus recorder the ability to set custom label names to the metric.