### PR TITLE
Add response size metrics 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 ## 0.x.x / 2019-xx-xx
 
+* [FEATURE] Add metrics of HTTP response size in bytes.
 * [ENHANCEMENT] Make the label names of Prometheus recorder configurable.
 
 ## 0.1.0 / 2019-03-18

--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,34 @@ go-http-metrics knows how to measure http metrics in different metric formats, i
 
 If you are using a framework that isn't directly compatible with go's `http.Handler` interface from the std library, do not worry, there are multiple helpers available to get middlewares fo the most used http Go frameworks. If there isn't you can open an issue or a PR.
 
+## Table of contents
+
+- [Metrics](#metrics)
+- [Metrics recorder implementations](#metrics-recorder-implementations)
+- [Framework compatibility middlewares](#framework-compatibility-middlewares)
+- [Getting Started](#getting-started)
+- [Prometheus query examples](#prometheus-query-examples)
+- [Options](#options)
+  - [Middleware Options](#middleware-options)
+    - [Recorder](#recorder)
+    - [GroupedStatus](#groupedstatus)
+    - [DisableMeasureSize](#disablemeasuresize)
+    - [Custom handler ID](#custom-handler-id)
+  - [Prometheus recorder options](#prometheus-recorder-options)
+    - [Prefix](#prefix)
+    - [DurationBuckets](#durationbuckets)
+    - [Registry](#registry)
+    - [Label names](#label-names)
+- [Benchmarks](#benchmarks)
+
+## Metrics
+
+The metrics obtained with this middleware are the [most important ones][red] for a HTTP service.
+
+- Records the duration of the requests(with: code, handler, method).
+- Records the count of the requests(with: code, handler, method).
+- Records the size of the responses(with: code, handler, method).
+
 ## Metrics recorder implementations
 
 go-http-metrics is easy to extend to different metric backends by implementing `metrics.Recorder` interface.
@@ -62,13 +90,7 @@ func main() {
 
 For more examples check the [examples]. [default][default-example] and [custom][custom-example] are the examples for Go net/http std library users.
 
-## Metrics
-
-The metrics obtained with this middleware are the [most important ones][red] for a HTTP service.
-
-The middleware will measure the latency seconds of the requests using a histogram (latency), this will give us also the number of requests (rate), and the metric has the status codes (error rate):
-
-### Query examples
+## Prometheus query examples
 
 Get the request rate by handler:
 
@@ -115,6 +137,10 @@ This is the implementation of the metrics backend, by default it's a dummy recor
 
 Storing all the status codes could increase the cardinality of the metrics, usually this is not a common case because the used status codes by a service are not too much and are finite, but some services use a lot of different status codes, grouping the status on the `\dxx` form could impact the performance (in a good way) of the queries on Prometheus (as they are already aggregated), on the other hand it losses detail. For example the metrics code `code="401"`, `code="404"`, `code="403"` with this enabled option would end being `code="4xx"` label. By default is disabled.
 
+#### DisableMeasureSize
+
+This setting will disable measuring the size of the responses. By default measuring the size is enabled.
+
 #### Custom handler ID
 
 One of the options that you need to pass when wrapping the handler with the middleware is `handlerID`, this has 2 working ways.
@@ -147,10 +173,11 @@ The label names of the Prometheus metrics can be configured using `HandlerIDLabe
 
 ```text
 pkg: github.com/slok/go-http-metrics/middleware
-BenchmarkMiddlewareHandler/benchmark_with_default_settings.-4            1000000              1202 ns/op             256 B/op          6 allocs/op
-BenchmarkMiddlewareHandler/benchmark_with_grouped_status_code.-4         1000000              1356 ns/op             256 B/op          7 allocs/op
-BenchmarkMiddlewareHandler/benchmark_with_predefined_handler_ID-4        1000000              1019 ns/op             256 B/op          6 allocs/op
 
+BenchmarkMiddlewareHandler/benchmark_with_default_settings.-4            1000000              1062 ns/op             256 B/op          6 allocs/op
+BenchmarkMiddlewareHandler/benchmark_disabling_measuring_size.-4         1000000              1101 ns/op             256 B/op          6 allocs/op
+BenchmarkMiddlewareHandler/benchmark_with_grouped_status_code.-4         1000000              1324 ns/op             256 B/op          7 allocs/op
+BenchmarkMiddlewareHandler/benchmark_with_predefined_handler_ID-4        1000000              1155 ns/op             256 B/op          6 allocs/op
 ```
 
 [travis-image]: https://travis-ci.org/slok/go-http-metrics.svg?branch=master

--- a/internal/mocks/metrics/Recorder.go
+++ b/internal/mocks/metrics/Recorder.go
@@ -14,3 +14,8 @@ type Recorder struct {
 func (_m *Recorder) ObserveHTTPRequestDuration(id string, duration time.Duration, method string, code string) {
 	_m.Called(id, duration, method, code)
 }
+
+// ObserveHTTPResponseSize provides a mock function with given fields: id, sizeBytes, method, code
+func (_m *Recorder) ObserveHTTPResponseSize(id string, sizeBytes int64, method string, code string) {
+	_m.Called(id, sizeBytes, method, code)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -10,6 +10,8 @@ import (
 type Recorder interface {
 	// ObserveHTTPRequestDuration measures the duration of an HTTP request.
 	ObserveHTTPRequestDuration(id string, duration time.Duration, method, code string)
+	// ObserveHTTPResponseSize measures the size of an HTTP response in bytes.
+	ObserveHTTPResponseSize(id string, sizeBytes int64, method, code string)
 }
 
 // Dummy is a dummy recorder.
@@ -18,3 +20,4 @@ var Dummy = &dummy{}
 type dummy struct{}
 
 func (dummy) ObserveHTTPRequestDuration(id string, duration time.Duration, method, code string) {}
+func (dummy) ObserveHTTPResponseSize(id string, sizeBytes int64, method, code string)           {}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -30,6 +30,9 @@ func TestPrometheusRecorder(t *testing.T) {
 				r.ObserveHTTPRequestDuration("test1", 175*time.Millisecond, http.MethodGet, "200")
 				r.ObserveHTTPRequestDuration("test2", 50*time.Millisecond, http.MethodGet, "201")
 				r.ObserveHTTPRequestDuration("test3", 700*time.Millisecond, http.MethodPost, "500")
+				r.ObserveHTTPResponseSize("test4", 529930, http.MethodPost, "500")
+				r.ObserveHTTPResponseSize("test4", 231, http.MethodPost, "500")
+				r.ObserveHTTPResponseSize("test4", 99999999, http.MethodPatch, "429")
 			},
 			expMetrics: []string{
 				`http_request_duration_seconds_bucket{code="200",handler="test1",method="GET",le="0.005"} 0`,
@@ -73,6 +76,28 @@ func TestPrometheusRecorder(t *testing.T) {
 				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="10"} 1`,
 				`http_request_duration_seconds_bucket{code="500",handler="test3",method="POST",le="+Inf"} 1`,
 				`http_request_duration_seconds_count{code="500",handler="test3",method="POST"} 1`,
+
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="100"} 0`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="1000"} 0`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="10000"} 0`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="100000"} 0`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="1e+06"} 0`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="1e+07"} 0`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="1e+08"} 1`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="1e+09"} 1`,
+				`http_response_size_bytes_bucket{code="429",handler="test4",method="PATCH",le="+Inf"} 1`,
+				`http_response_size_bytes_count{code="429",handler="test4",method="PATCH"} 1`,
+
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="100"} 0`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="1000"} 1`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="10000"} 1`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="100000"} 1`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="1e+06"} 2`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="1e+07"} 2`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="1e+08"} 2`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="1e+09"} 2`,
+				`http_response_size_bytes_bucket{code="500",handler="test4",method="POST",le="+Inf"} 2`,
+				`http_response_size_bytes_count{code="500",handler="test4",method="POST"} 2`,
 			},
 		},
 		{

--- a/middleware/gorestful/gorestful_test.go
+++ b/middleware/gorestful/gorestful_test.go
@@ -48,6 +48,7 @@ func TestMiddlewareIntegration(t *testing.T) {
 			// Mocks.
 			mr := &mmetrics.Recorder{}
 			mr.On("ObserveHTTPRequestDuration", test.expHandlerID, mock.Anything, test.expMethod, test.expStatusCode)
+			mr.On("ObserveHTTPResponseSize", test.expHandlerID, mock.Anything, test.expMethod, test.expStatusCode)
 
 			// Create our instance with the middleware.
 			mdlw := middleware.New(middleware.Config{Recorder: mr})

--- a/middleware/httprouter/httprouter_test.go
+++ b/middleware/httprouter/httprouter_test.go
@@ -48,6 +48,7 @@ func TestMiddlewareIntegration(t *testing.T) {
 			// Mocks.
 			mr := &mmetrics.Recorder{}
 			mr.On("ObserveHTTPRequestDuration", test.expHandlerID, mock.Anything, test.expMethod, test.expStatusCode)
+			mr.On("ObserveHTTPResponseSize", test.expHandlerID, mock.Anything, test.expMethod, test.expStatusCode)
 
 			// Create our instance with the middleware.
 			mdlw := middleware.New(middleware.Config{Recorder: mr})

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -11,9 +11,10 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func getFakeHandler(statusCode int) http.Handler {
+func getFakeHandler(statusCode int, responseBody string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(statusCode)
+		w.Write([]byte(responseBody))
 	})
 }
 
@@ -21,27 +22,33 @@ func TestMiddlewareHandler(t *testing.T) {
 	tests := []struct {
 		name          string
 		handlerID     string
+		body          string
 		statusCode    int
 		req           *http.Request
 		config        middleware.Config
 		expHandlerID  string
 		expMethod     string
+		expSize       int64
 		expStatusCode string
 	}{
 		{
 			name:          "A default HTTP middleware should call the recorder to measure.",
 			statusCode:    http.StatusAccepted,
+			body:          "Я бэтмен",
 			req:           httptest.NewRequest(http.MethodGet, "/test", nil),
 			expHandlerID:  "/test",
+			expSize:       15,
 			expMethod:     http.MethodGet,
 			expStatusCode: "202",
 		},
 		{
 			name:          "Using custom ID in the middleware should call the recorder to measure with that ID.",
 			handlerID:     "customID",
+			body:          "I'm Batman",
 			statusCode:    http.StatusTeapot,
 			req:           httptest.NewRequest(http.MethodPost, "/test", nil),
 			expHandlerID:  "customID",
+			expSize:       10,
 			expMethod:     http.MethodPost,
 			expStatusCode: "418",
 		},
@@ -61,11 +68,12 @@ func TestMiddlewareHandler(t *testing.T) {
 			// Mocks.
 			mr := &mmetrics.Recorder{}
 			mr.On("ObserveHTTPRequestDuration", test.expHandlerID, mock.Anything, test.expMethod, test.expStatusCode)
+			mr.On("ObserveHTTPResponseSize", test.expHandlerID, test.expSize, test.expMethod, test.expStatusCode)
 
 			// Make the request.
 			test.config.Recorder = mr
 			m := middleware.New(test.config)
-			h := m.Handler(test.handlerID, getFakeHandler(test.statusCode))
+			h := m.Handler(test.handlerID, getFakeHandler(test.statusCode, test.body))
 			h.ServeHTTP(httptest.NewRecorder(), test.req)
 
 			mr.AssertExpectations(t)
@@ -87,6 +95,13 @@ func BenchmarkMiddlewareHandler(b *testing.B) {
 			cfg:       middleware.Config{},
 		},
 		{
+			name:      "benchmark disabling measuring size.",
+			handlerID: "",
+			cfg: middleware.Config{
+				DisableMeasureSize: true,
+			},
+		},
+		{
 			name: "benchmark with grouped status code.",
 			cfg: middleware.Config{
 				GroupedStatus: true,
@@ -104,7 +119,7 @@ func BenchmarkMiddlewareHandler(b *testing.B) {
 			// Prepare.
 			bench.cfg.Recorder = metrics.Dummy
 			m := middleware.New(bench.cfg)
-			h := m.Handler(bench.handlerID, getFakeHandler(200))
+			h := m.Handler(bench.handlerID, getFakeHandler(200, ""))
 			r := httptest.NewRequest("GET", "/test", nil)
 
 			// Make the requests.

--- a/middleware/negroni/negroni_test.go
+++ b/middleware/negroni/negroni_test.go
@@ -48,6 +48,7 @@ func TestMiddlewareIntegration(t *testing.T) {
 			// Mocks.
 			mr := &mmetrics.Recorder{}
 			mr.On("ObserveHTTPRequestDuration", test.expHandlerID, mock.Anything, test.expMethod, test.expStatusCode)
+			mr.On("ObserveHTTPResponseSize", test.expHandlerID, mock.Anything, test.expMethod, test.expStatusCode)
 
 			// Create our negroni instance with the middleware.
 			mdlw := middleware.New(middleware.Config{Recorder: mr})


### PR DESCRIPTION
This PR adds support for recording response size metrics with it's Prometheus implementation, example:
```
# HELP http_response_size_bytes The size of the HTTP responses.
# TYPE http_response_size_bytes histogram
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="100"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="1000"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="10000"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="100000"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="1e+06"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="1e+07"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="1e+08"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="1e+09"} 36
http_response_size_bytes_bucket{code="200",handler="/",method="GET",le="+Inf"} 36
http_response_size_bytes_sum{code="200",handler="/",method="GET"} 432
http_response_size_bytes_count{code="200",handler="/",method="GET"} 36
```

By default is enabled, but can be disabled with `DisableMeasureSize` middleware setting.

Fixes #9 
