### PR TITLE
Allow for pre-registering metrics labels in registrerer

### DIFF
--- a/internal/mocks/metrics/Recorder.go
+++ b/internal/mocks/metrics/Recorder.go
@@ -26,3 +26,18 @@ func (_m *Recorder) ObserveHTTPRequestDuration(ctx context.Context, id string, d
 func (_m *Recorder) ObserveHTTPResponseSize(ctx context.Context, id string, sizeBytes int64, method string, code string) {
 	_m.Called(ctx, id, sizeBytes, method, code)
 }
+
+// RegisterHTTPRequestDurationValues provides a mock function with given fields: id, method, code
+func (_m *Recorder) RegisterHTTPRequestDurationValues(id string, method string, code string) {
+	_m.Called(id, method, code)
+}
+
+// RegisterHTTPResponseSizeValues provides a mock function with given fields: id, method, code
+func (_m *Recorder) RegisterHTTPResponseSizeValues(id string, method string, code string) {
+	_m.Called(id, method, code)
+}
+
+// RegisterInflightRequestsValues provides a mock function with given fields: id
+func (_m *Recorder) RegisterInflightRequestsValues(id string) {
+	_m.Called(id)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -16,6 +16,21 @@ type Recorder interface {
 	// AddInflightRequests increments and decrements the number of inflight request being
 	// processed.
 	AddInflightRequests(ctx context.Context, id string, quantity int)
+
+	// RegisterHTTPRequestDurationValues allows for pre-registering values of id,
+	// duration, method and code so that the coresponding metrics are emited
+	// right from the start of the recorder and not just with the first request
+	RegisterHTTPRequestDurationValues(id string, method, code string)
+
+	// RegisterHTTPResponseSizeValues allows for pre-registering values of id,
+	// duration, method and code so that the coresponding metrics are emited
+	// right from the start of the recorder and not just with the first request
+	RegisterHTTPResponseSizeValues(id string, method, code string)
+
+	// RegisterInflightRequestsValues allows for pre-registering values of id,
+	// duration, method and code so that the coresponding metrics are emited
+	// right from the start of the recorder and not just with the first request
+	RegisterInflightRequestsValues(id string)
 }
 
 // Dummy is a dummy recorder.
@@ -28,3 +43,10 @@ func (dummy) ObserveHTTPRequestDuration(ctx context.Context, id string, duration
 func (dummy) ObserveHTTPResponseSize(ctx context.Context, id string, sizeBytes int64, method, code string) {
 }
 func (dummy) AddInflightRequests(ctx context.Context, id string, quantity int) {}
+
+func (dummy) RegisterHTTPRequestDurationValues(id string, method, code string) {
+}
+func (dummy) RegisterHTTPResponseSizeValues(id string, method, code string) {
+}
+func (dummy) RegisterInflightRequestsValues(id string) {
+}

--- a/metrics/opencensus/opencensus.go
+++ b/metrics/opencensus/opencensus.go
@@ -195,3 +195,13 @@ func (r recorder) AddInflightRequests(ctx context.Context, id string, quantity i
 
 	stats.Record(ctx, r.inflightCount.M(int64(quantity)))
 }
+
+func (r recorder) RegisterHTTPRequestDurationValues(id string, method, code string) {
+
+}
+
+func (r recorder) RegisterHTTPResponseSizeValues(id string, method, code string) {
+}
+
+func (r recorder) RegisterInflightRequestsValues(id string) {
+}

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -118,3 +118,24 @@ func (r recorder) ObserveHTTPResponseSize(_ context.Context, id string, sizeByte
 func (r recorder) AddInflightRequests(_ context.Context, id string, quantity int) {
 	r.httpRequestsInflight.WithLabelValues(id).Add(float64(quantity))
 }
+
+// RegisterHTTPRequestDurationValues allows for pre-registering values of id,
+// duration, method and code so that the coresponding metrics are emited
+// right from the start of the recorder and not just with the first request
+func (r recorder) RegisterHTTPRequestDurationValues(id string, method, code string) {
+	r.httpRequestDurHistogram.WithLabelValues(id, method, code)
+}
+
+// RegisterHTTPResponseSizeValues allows for pre-registering values of id,
+// duration, method and code so that the coresponding metrics are emited
+// right from the start of the recorder and not just with the first request
+func (r recorder) RegisterHTTPResponseSizeValues(id string, method, code string) {
+	r.httpResponseSizeHistogram.WithLabelValues(id, method, code)
+}
+
+// RegisterInflightRequestsValues allows for pre-registering values of id,
+// duration, method and code so that the coresponding metrics are emited
+// right from the start of the recorder and not just with the first request
+func (r recorder) RegisterInflightRequestsValues(id string) {
+	r.httpRequestsInflight.WithLabelValues(id)
+}


### PR DESCRIPTION
This change introduces methods in recorder that allow for warming up the HTTP metrics. 

Instead of metrics being added as new HTTP requests are being made, it is possible now to predefine them upfront. My use case is testing - during the integration tests of my application, I doublecheck that all the metrics have registered and are available. Having metrics auto-generated makes the test flaky as the list of metrics available depends on the API calls made so far.

I do not know how to approach opencensus recorder though - I am unfamiliar with it and for now, just added empty methods.

Happy to discuss and adjust!