### PR TITLE
Omit 404 status

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -140,6 +140,10 @@ This setting will disable measuring the size of the responses. By default measur
 
 This settings will disable measuring the number of requests being handled concurrently by the handlers.
 
+#### DisableMeasureNotFoundStatus 
+
+This setting will disable measuring duration and size when status is 404 not found, this prevents from producing results for non-existent endpoints. Most frameworks return 404 when there is no handler for the request, but 404 can still be returned for an endpoint with a handler, so use with caution.  
+
 #### Custom handler ID
 
 One of the options that you need to pass when wrapping the handler with the middleware is `handlerID`, this has 2 working ways.

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -29,9 +29,9 @@ type Config struct {
 	// DisableMeasureInflight will disable the recording metrics about the inflight requests number,
 	// by default measuring inflights is enabled (`DisableMeasureInflight` is false).
 	DisableMeasureInflight bool
-	// OmitNotFoundStatus omit recording data when status is 404 not found, this prevents from producing
-	// results for non-exists endpoints
-	OmitNotFoundStatus bool
+	// DisableMeasureNotFoundStatus omit recording data when status is 404 not found, this prevents from producing
+	// results for non-existent endpoints
+	DisableMeasureNotFoundStatus bool
 }
 
 func (c *Config) validate() {
@@ -102,7 +102,7 @@ func (m *middleware) Handler(handlerID string, h http.Handler) http.Handler {
 			// first number of the status code because is the least
 			// required identification way.
 			var code string
-			if m.cfg.OmitNotFoundStatus && wi.statusCode == 404 {
+			if m.cfg.DisableMeasureNotFoundStatus && wi.statusCode == http.StatusNotFound {
 				return
 			}
 			if m.cfg.GroupedStatus {


### PR DESCRIPTION
For open APIs there would be requests to non-existent endpoints, we would like to ignore those requests when recording to avoid unnecessary results 