### PR TITLE
Add customized labels based on HTTP header

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -16,6 +16,8 @@ type HTTPReqProperties struct {
 	Method string
 	// Code is the response of the request.
 	Code string
+	// CustomizedLabels is the customized header
+	Labels map[string]string
 }
 
 // HTTPProperties are the metric properties for the global server metrics.

--- a/middleware/echo/echo.go
+++ b/middleware/echo/echo.go
@@ -35,3 +35,5 @@ func (r *reporter) URLPath() string { return r.c.Request().URL.Path }
 func (r *reporter) StatusCode() int { return r.c.Response().Status }
 
 func (r *reporter) BytesWritten() int64 { return r.c.Response().Size }
+
+func (r *reporter) CustomHeaders() map[string]string { return make(map[string]string) }

--- a/middleware/fasthttp/fasthttp.go
+++ b/middleware/fasthttp/fasthttp.go
@@ -40,3 +40,5 @@ func (r reporter) StatusCode() int {
 func (r reporter) BytesWritten() int64 {
 	return int64(len(r.c.Response.Body()))
 }
+
+func (r reporter) CustomHeaders() map[string]string { return make(map[string]string) }

--- a/middleware/gin/gin.go
+++ b/middleware/gin/gin.go
@@ -32,3 +32,5 @@ func (r *reporter) URLPath() string { return r.c.Request.URL.Path }
 func (r *reporter) StatusCode() int { return r.c.Writer.Status() }
 
 func (r *reporter) BytesWritten() int64 { return int64(r.c.Writer.Size()) }
+
+func (r *reporter) CustomHeaders() map[string]string { return make(map[string]string) }

--- a/middleware/gorestful/gorestful.go
+++ b/middleware/gorestful/gorestful.go
@@ -33,3 +33,5 @@ func (r *reporter) URLPath() string { return r.req.Request.URL.Path }
 func (r *reporter) StatusCode() int { return r.resp.StatusCode() }
 
 func (r *reporter) BytesWritten() int64 { return int64(r.resp.ContentLength()) }
+
+func (r *reporter) CustomHeaders() map[string]string { return make(map[string]string) }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -99,11 +99,16 @@ func (m Middleware) Measure(handlerID string, reporter Reporter, next func()) {
 			code = strconv.Itoa(reporter.StatusCode())
 		}
 
+		labels := make(map[string]string)
+		for k, v := range reporter.CustomHeaders() {
+			labels[k] = v
+		}
 		props := metrics.HTTPReqProperties{
 			Service: m.cfg.Service,
 			ID:      hid,
 			Method:  reporter.Method(),
 			Code:    code,
+			Labels:  labels,
 		}
 		m.cfg.Recorder.ObserveHTTPRequestDuration(ctx, props, duration)
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -124,5 +124,6 @@ type Reporter interface {
 	Context() context.Context
 	URLPath() string
 	StatusCode() int
+	CustomHeaders() map[string]string
 	BytesWritten() int64
 }

--- a/middleware/std/std.go
+++ b/middleware/std/std.go
@@ -52,6 +52,8 @@ func (s *stdReporter) StatusCode() int { return s.w.statusCode }
 
 func (s *stdReporter) BytesWritten() int64 { return int64(s.w.bytesWritten) }
 
+func (s *stdReporter) CustomHeaders() map[string]string { return make(map[string]string) }
+
 // responseWriterInterceptor is a simple wrapper to intercept set data on a
 // ResponseWriter.
 type responseWriterInterceptor struct {


### PR DESCRIPTION
This PR allows to add customized labels based on HTTP header. A custom reporter can define a list of customized labels. A new function CustomHeader can parse the header and add them into the prometheus as labels.