### PR TITLE
Reduce HandlerID cardinality by default in gin middleware

### DIFF
--- a/middleware/gin/gin.go
+++ b/middleware/gin/gin.go
@@ -27,7 +27,7 @@ func (r *reporter) Method() string { return r.c.Request.Method }
 
 func (r *reporter) Context() context.Context { return r.c.Request.Context() }
 
-func (r *reporter) URLPath() string { return r.c.Request.URL.Path }
+func (r *reporter) URLPath() string { return r.c.FullPath() }
 
 func (r *reporter) StatusCode() int { return r.c.Writer.Status() }
 


### PR DESCRIPTION
Here's the doc for FullPath()
```
FullPath returns a matched route full path. For not found routes
returns an empty string.
    router.GET("/user/:id", func(c *gin.Context) {
        c.FullPath() == "/user/:id" // true
    })
```

IMO it's better to do the correct thing by default when possible; existing users would benefit from performance increases but it may break some dashboards.

Let me know what you think,
Thanks!