### PR TITLE
Allow Reporter to provide handler ID after the underlying call.

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -99,6 +99,12 @@ func (m Middleware) Measure(handlerID string, reporter Reporter, next func()) {
 			code = strconv.Itoa(reporter.StatusCode())
 		}
 
+		// If reporter was unable to provide a handler ID *before* calling the underlying
+		// handler, give it a chance to report it *after* the call.
+		if hid == "" {
+			hid = reporter.URLPath()
+		}
+
 		props := metrics.HTTPReqProperties{
 			Service: m.cfg.Service,
 			ID:      hid,


### PR DESCRIPTION
This enables metrics collection from "black-box" muxers like the one in grpc-gateway.