### PR TITLE
Add IgnoredPaths option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -155,6 +155,10 @@ This setting will disable measuring the size of the responses. By default measur
 
 This settings will disable measuring the number of requests being handled concurrently by the handlers.
 
+### IgnoredPaths
+
+This setting is a list of paths that will not be measured for the request duration and the response size. They will still be counted in the RequestsInflight metric.
+
 #### Custom handler ID
 
 One of the options that you need to pass when wrapping the handler with the middleware is `handlerID`, this has 2 working ways.

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -34,7 +34,7 @@ type Config struct {
 	DisableMeasureInflight bool
 	// IgnoredPaths is a list of paths that will not be measured for the request duration
 	// and the response size. They will still be counted in the RequestsInflight metric.
-	IgnoredPaths []string
+	IgnoredPaths map[string]struct{}
 }
 
 func (c *Config) defaults() {
@@ -90,10 +90,8 @@ func (m Middleware) Measure(handlerID string, reporter Reporter, next func()) {
 	// Start the timer and when finishing measure the duration.
 	start := time.Now()
 	defer func() {
-		for _, path := range m.cfg.IgnoredPaths {
-			if path == reporter.URLPath() {
-				return
-			}
+		if _, isPathIgnored := m.cfg.IgnoredPaths[reporter.URLPath()]; isPathIgnored {
+			return
 		}
 
 		duration := time.Since(start)

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -32,6 +32,7 @@ func TestMiddlewareMeasure(t *testing.T) {
 				mrep.On("StatusCode").Once().Return(418)
 				mrep.On("Method").Once().Return("PATCH")
 				mrep.On("BytesWritten").Once().Return(int64(42))
+				mrep.On("URLPath").Once().Return("/test/01")
 
 				// Recorder mocks.
 				expProps := metrics.HTTPProperties{Service: "svc1", ID: "test01"}
@@ -41,6 +42,35 @@ func TestMiddlewareMeasure(t *testing.T) {
 				mrec.On("AddInflightRequests", mock.Anything, expProps, -1).Once()
 				mrec.On("ObserveHTTPRequestDuration", mock.Anything, expRepProps, mock.Anything).Once()
 				mrec.On("ObserveHTTPResponseSize", mock.Anything, expRepProps, int64(42)).Once()
+			},
+		},
+
+		"Having an ignored path in the config, it should not measure the metrics for the ignored path.": {
+			handlerID: "test01",
+			config: func() middleware.Config {
+				return middleware.Config{
+					Service: "svc1",
+					IgnoredPaths: map[string]struct{}{
+						"/ignored": {},
+					},
+				}
+			},
+			mock: func(mrec *mockmetrics.Recorder, mrep *mockmiddleware.Reporter) {
+				// Reporter mocks.
+				mrep.On("Context").Once().Return(context.TODO())
+				mrep.AssertNotCalled(t, "StatusCode")
+				mrep.AssertNotCalled(t, "Method")
+				mrep.AssertNotCalled(t, "BytesWritten")
+				mrep.On("URLPath").Once().Return("/ignored")
+
+				// Recorder mocks.
+				expProps := metrics.HTTPProperties{Service: "svc1", ID: "test01"}
+				expRepProps := metrics.HTTPReqProperties{Service: "svc1", ID: "test01", Method: "PATCH", Code: "418"}
+
+				mrec.On("AddInflightRequests", mock.Anything, expProps, 1).Once()
+				mrec.On("AddInflightRequests", mock.Anything, expProps, -1).Once()
+				mrec.AssertNotCalled(t, "ObserveHTTPRequestDuration", mock.Anything, expRepProps, mock.Anything)
+				mrec.AssertNotCalled(t, "ObserveHTTPResponseSize", mock.Anything, expRepProps, int64(42))
 			},
 		},
 
@@ -56,6 +86,7 @@ func TestMiddlewareMeasure(t *testing.T) {
 				mrep.On("StatusCode").Once().Return(418)
 				mrep.On("Method").Once().Return("PATCH")
 				mrep.On("BytesWritten").Once().Return(int64(42))
+				mrep.On("URLPath").Once().Return("/test/01")
 
 				// Recorder mocks.
 				expRepProps := metrics.HTTPReqProperties{ID: "/test/01", Method: "PATCH", Code: "418"}
@@ -80,6 +111,7 @@ func TestMiddlewareMeasure(t *testing.T) {
 				mrep.On("StatusCode").Once().Return(418)
 				mrep.On("Method").Once().Return("PATCH")
 				mrep.On("BytesWritten").Once().Return(int64(42))
+				mrep.On("URLPath").Once().Return("/test/01")
 
 				// Recorder mocks.
 				expRepProps := metrics.HTTPReqProperties{ID: "test01", Method: "PATCH", Code: "4xx"}
@@ -104,6 +136,7 @@ func TestMiddlewareMeasure(t *testing.T) {
 				mrep.On("StatusCode").Once().Return(418)
 				mrep.On("Method").Once().Return("PATCH")
 				mrep.On("BytesWritten").Once().Return(int64(42))
+				mrep.On("URLPath").Once().Return("/test/01")
 
 				// Recorder mocks.
 				expRepProps := metrics.HTTPReqProperties{ID: "test01", Method: "PATCH", Code: "418"}
@@ -125,6 +158,7 @@ func TestMiddlewareMeasure(t *testing.T) {
 				mrep.On("Context").Once().Return(context.TODO())
 				mrep.On("StatusCode").Once().Return(418)
 				mrep.On("Method").Once().Return("PATCH")
+				mrep.On("URLPath").Once().Return("/test/01")
 
 				// Recorder mocks.
 				expRepProps := metrics.HTTPReqProperties{ID: "test01", Method: "PATCH", Code: "418"}


### PR DESCRIPTION
Close #100

With this diff:

```diff
diff --git a/examples/default/main.go b/examples/default/main.go
index b5bcc33..3c69f1e 100644
--- a/examples/default/main.go
+++ b/examples/default/main.go
@@ -29,7 +29,8 @@ const (
 func main() {
 	// Create our middleware.
 	mdlw := middleware.New(middleware.Config{
-		Recorder: metrics.NewRecorder(metrics.Config{}),
+		Recorder:    metrics.NewRecorder(metrics.Config{}),
+		IgnoredPaths: []string{"/test1"},
 	})
 
 	// Create our server.

```

```
➜ curl localhost:8080/test1
➜ curl localhost:8080/test2
```

Resulting metrics:

```
➜ curl -s localhost:8081/metrics | grep -v '#' | grep -v 'go_' | grep -v promhttp
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="0.005"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="0.01"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="0.025"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="0.05"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="0.1"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="0.25"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="0.5"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="1"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="2.5"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="5"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="10"} 1
http_request_duration_seconds_bucket{code="204",handler="/test2",method="GET",service="",le="+Inf"} 1
http_request_duration_seconds_sum{code="204",handler="/test2",method="GET",service=""} 3.558e-06
http_request_duration_seconds_count{code="204",handler="/test2",method="GET",service=""} 1
http_requests_inflight{handler="/test1",service=""} 0
http_requests_inflight{handler="/test2",service=""} 0
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="100"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="1000"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="10000"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="100000"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="1e+06"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="1e+07"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="1e+08"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="1e+09"} 1
http_response_size_bytes_bucket{code="204",handler="/test2",method="GET",service="",le="+Inf"} 1
http_response_size_bytes_sum{code="204",handler="/test2",method="GET",service=""} 0
http_response_size_bytes_count{code="204",handler="/test2",method="GET",service=""} 1
```