### PR TITLE
Add the handlerID to various request contexts for downstream use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 .test_coverage.txt
+.idea

--- a/middleware/echo/echo.go
+++ b/middleware/echo/echo.go
@@ -12,6 +12,7 @@ import (
 func Handler(handlerID string, m middleware.Middleware) echo.MiddlewareFunc {
 	return func(h echo.HandlerFunc) echo.HandlerFunc {
 		return echo.HandlerFunc(func(c echo.Context) error {
+			c.Set(middleware.HandlerIDCtx, handlerID)
 			r := &reporter{c: c}
 			var err error
 			m.Measure(handlerID, r, func() {

--- a/middleware/fasthttp/fasthttp.go
+++ b/middleware/fasthttp/fasthttp.go
@@ -11,6 +11,7 @@ import (
 // Handler returns a fasthttp measuring middleware.
 func Handler(handlerID string, m middleware.Middleware, next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(c *fasthttp.RequestCtx) {
+		c.SetUserValue(middleware.HandlerIDCtx, handlerID)
 		m.Measure(handlerID, reporter{c}, func() {
 			next(c)
 		})

--- a/middleware/gin/gin.go
+++ b/middleware/gin/gin.go
@@ -12,6 +12,7 @@ import (
 // Handler returns a Gin measuring middleware.
 func Handler(handlerID string, m middleware.Middleware) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		c.Set(middleware.HandlerIDCtx, handlerID)
 		r := &reporter{c: c}
 		m.Measure(handlerID, r, func() {
 			c.Next()

--- a/middleware/gorestful/gorestful.go
+++ b/middleware/gorestful/gorestful.go
@@ -12,6 +12,7 @@ import (
 // Handler returns a gorestful measuring middleware.
 func Handler(handlerID string, m middleware.Middleware) gorestful.FilterFunction {
 	return func(req *gorestful.Request, resp *gorestful.Response, chain *gorestful.FilterChain) {
+		req.SetAttribute(middleware.HandlerIDCtx, handlerID)
 		r := &reporter{req: req, resp: resp}
 		m.Measure(handlerID, r, func() {
 			chain.ProcessFilter(req, resp)

--- a/middleware/httprouter/httprouter.go
+++ b/middleware/httprouter/httprouter.go
@@ -2,6 +2,7 @@
 package httprouter
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -15,7 +16,9 @@ func Handler(handlerID string, next httprouter.Handle, m middleware.Middleware) 
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		// Dummy handler to wrap httprouter Handle type.
 		h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next(w, r, p)
+			ctx := context.WithValue(r.Context(), middleware.HandlerIDCtx, handlerID)
+			req := r.WithContext(ctx)
+			next(w, req, p)
 		})
 
 		std.Handler(handlerID, m, h).ServeHTTP(w, r)

--- a/middleware/iris/iris.go
+++ b/middleware/iris/iris.go
@@ -12,6 +12,9 @@ import (
 // Handler returns a Iris measuring middleware.
 func Handler(handlerID string, m middleware.Middleware) iris.Handler {
 	return func(ctx iris.Context) {
+		c := context.WithValue(ctx.Request().Context(), middleware.HandlerIDCtx, handlerID)
+		req := ctx.Request().WithContext(c)
+		ctx.ResetRequest(req)
 		r := &reporter{ctx: ctx}
 		m.Measure(handlerID, r, func() {
 			ctx.Next()

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -13,6 +13,8 @@ import (
 	"github.com/slok/go-http-metrics/metrics"
 )
 
+const HandlerIDCtx = "HandlerIDCtx"
+
 // Config is the configuration for the middleware factory.
 type Config struct {
 	// Recorder is the way the metrics will be recorder in the different backends.

--- a/middleware/negroni/negroni.go
+++ b/middleware/negroni/negroni.go
@@ -2,6 +2,7 @@
 package negroni
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/urfave/negroni"
@@ -13,6 +14,8 @@ import (
 // Handler returns a Negroni measuring middleware.
 func Handler(handlerID string, m middleware.Middleware) negroni.Handler {
 	return negroni.HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
-		std.Handler(handlerID, m, next).ServeHTTP(rw, r)
+		ctx := context.WithValue(r.Context(), middleware.HandlerIDCtx, handlerID)
+		req := r.WithContext(ctx)
+		std.Handler(handlerID, m, next).ServeHTTP(rw, req)
 	})
 }

--- a/middleware/std/std.go
+++ b/middleware/std/std.go
@@ -14,17 +14,19 @@ import (
 // Handler returns an measuring standard http.Handler.
 func Handler(handlerID string, m middleware.Middleware, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), middleware.HandlerIDCtx, handlerID)
+		req := r.WithContext(ctx)
 		wi := &responseWriterInterceptor{
 			statusCode:     http.StatusOK,
 			ResponseWriter: w,
 		}
 		reporter := &stdReporter{
 			w: wi,
-			r: r,
+			r: req,
 		}
 
 		m.Measure(handlerID, reporter, func() {
-			h.ServeHTTP(wi, r)
+			h.ServeHTTP(wi, req)
 		})
 	})
 }


### PR DESCRIPTION
I want to be able to use the handlerID in downstream contexts. This PR adds it to the various framework's context equivalents if possible.

Kind of hard to add tests for this as we don't have access to the request context. It's probably possible to mock it but these changes seem pretty impotent.