### PR TITLE
Add config for the gorestful middleware

### DIFF
--- a/middleware/gorestful/example_test.go
+++ b/middleware/gorestful/example_test.go
@@ -24,7 +24,7 @@ func Example_gorestfulMiddleware() {
 	c := gorestful.NewContainer()
 
 	// Add the middleware for all routes.
-	c.Filter(gorestfulmiddleware.Handler("", mdlw))
+	c.Filter(gorestfulmiddleware.HandlerWithConfig("", mdlw, gorestfulmiddleware.Config{}))
 
 	// Add our handler,
 	ws := &gorestful.WebService{}

--- a/middleware/gorestful/gorestful.go
+++ b/middleware/gorestful/gorestful.go
@@ -9,10 +9,20 @@ import (
 	"github.com/slok/go-http-metrics/middleware"
 )
 
-// Handler returns a gorestful measuring middleware.
+// Config is the configuration for the gorestful middleware.
+type Config struct {
+	UseRoutePath bool // When true, aggregate requests by their route path.  For example, "/users/{id}" instead of "/users/1", "/users/2", etc.
+}
+
+// Handler returns a gorestful measuring middleware with the default config.
 func Handler(handlerID string, m middleware.Middleware) gorestful.FilterFunction {
+	return HandlerWithConfig(handlerID, m, Config{})
+}
+
+// HandlerWithConfig returns a gorestful measuring middleware.
+func HandlerWithConfig(handlerID string, m middleware.Middleware, config Config) gorestful.FilterFunction {
 	return func(req *gorestful.Request, resp *gorestful.Response, chain *gorestful.FilterChain) {
-		r := &reporter{req: req, resp: resp}
+		r := &reporter{req: req, resp: resp, config: config}
 		m.Measure(handlerID, r, func() {
 			chain.ProcessFilter(req, resp)
 		})
@@ -20,15 +30,21 @@ func Handler(handlerID string, m middleware.Middleware) gorestful.FilterFunction
 }
 
 type reporter struct {
-	req  *gorestful.Request
-	resp *gorestful.Response
+	req    *gorestful.Request
+	resp   *gorestful.Response
+	config Config
 }
 
 func (r *reporter) Method() string { return r.req.Request.Method }
 
 func (r *reporter) Context() context.Context { return r.req.Request.Context() }
 
-func (r *reporter) URLPath() string { return r.req.Request.URL.Path }
+func (r *reporter) URLPath() string {
+	if r.config.UseRoutePath {
+		return r.req.SelectedRoutePath()
+	}
+	return r.req.Request.URL.Path
+}
 
 func (r *reporter) StatusCode() int { return r.resp.StatusCode() }
 


### PR DESCRIPTION
One of the benefits of using gorestful is its fancy routes, which
let you specify "path parameters" such as "/users/{id}".  This
change adds a "Config" structure for the gorestful middleware that
allows you to use the gorestful route path and not the actual
request path.

For backward compatibility, this introduces the "HandlerWithConfig"
function, and the existing "Handler" function calls "HandlerWithConfig"
with the default "Config".

The example has been updated to use "HandlerWithConfig".