### PR TITLE
Allow extra properties derived from request

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -16,6 +16,9 @@ type HTTPReqProperties struct {
 	Method string
 	// Code is the response of the request.
 	Code string
+	// ExtraProperties holds any extra properties that may be extracted from
+	// the request and use by a recorder.
+	ExtraProperties map[string]interface{}
 }
 
 // HTTPProperties are the metric properties for the global server metrics.
@@ -24,6 +27,9 @@ type HTTPProperties struct {
 	Service string
 	// ID is the id of the request handler.
 	ID string
+	// ExtraProperties holds any extra properties that may be extracted from
+	// the request and use by a recorder.
+	ExtraProperties map[string]interface{}
 }
 
 // Recorder knows how to record and measure the metrics. This

--- a/middleware/echo/echo.go
+++ b/middleware/echo/echo.go
@@ -14,7 +14,7 @@ func Handler(handlerID string, m middleware.Middleware) echo.MiddlewareFunc {
 		return echo.HandlerFunc(func(c echo.Context) error {
 			r := &reporter{c: c}
 			var err error
-			m.Measure(handlerID, r, func() {
+			m.Measure(handlerID, r, c, func() {
 				err = h(c)
 			})
 			return err

--- a/middleware/fasthttp/fasthttp.go
+++ b/middleware/fasthttp/fasthttp.go
@@ -11,7 +11,7 @@ import (
 // Handler returns a fasthttp measuring middleware.
 func Handler(handlerID string, m middleware.Middleware, next fasthttp.RequestHandler) fasthttp.RequestHandler {
 	return func(c *fasthttp.RequestCtx) {
-		m.Measure(handlerID, reporter{c}, func() {
+		m.Measure(handlerID, reporter{c}, c, func() {
 			next(c)
 		})
 	}

--- a/middleware/gin/gin.go
+++ b/middleware/gin/gin.go
@@ -13,7 +13,7 @@ import (
 func Handler(handlerID string, m middleware.Middleware) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		r := &reporter{c: c}
-		m.Measure(handlerID, r, func() {
+		m.Measure(handlerID, r, c, func() {
 			c.Next()
 		})
 	}

--- a/middleware/gorestful/gorestful.go
+++ b/middleware/gorestful/gorestful.go
@@ -13,7 +13,7 @@ import (
 func Handler(handlerID string, m middleware.Middleware) gorestful.FilterFunction {
 	return func(req *gorestful.Request, resp *gorestful.Response, chain *gorestful.FilterChain) {
 		r := &reporter{req: req, resp: resp}
-		m.Measure(handlerID, r, func() {
+		m.Measure(handlerID, r, req, func() {
 			chain.ProcessFilter(req, resp)
 		})
 	}

--- a/middleware/iris/iris.go
+++ b/middleware/iris/iris.go
@@ -13,7 +13,7 @@ import (
 func Handler(handlerID string, m middleware.Middleware) iris.Handler {
 	return func(ctx iris.Context) {
 		r := &reporter{ctx: ctx}
-		m.Measure(handlerID, r, func() {
+		m.Measure(handlerID, r, ctx, func() {
 			ctx.Next()
 		})
 	}

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -151,7 +151,7 @@ func TestMiddlewareMeasure(t *testing.T) {
 			mdlw := middleware.New(config)
 
 			calledNext := false
-			mdlw.Measure(test.handlerID, mrep, func() { calledNext = true })
+			mdlw.Measure(test.handlerID, mrep, nil, func() { calledNext = true })
 
 			// Check.
 			mrec.AssertExpectations(t)

--- a/middleware/std/std.go
+++ b/middleware/std/std.go
@@ -23,7 +23,7 @@ func Handler(handlerID string, m middleware.Middleware, h http.Handler) http.Han
 			r: r,
 		}
 
-		m.Measure(handlerID, reporter, func() {
+		m.Measure(handlerID, reporter, r, func() {
 			h.ServeHTTP(wi, r)
 		})
 	})


### PR DESCRIPTION
Hah, sent this PR to the wrong repo. Well, this could be valuable upstream here, but the work needs to be finished to hook into the rest of the metrics consumers, and the various HTTP middleware. It's currently only hooked up for the core http lib and prometheus.

Anyways, the goal here: allow extra labels to be produced based on the request values (values stored in the context, headers, etc) with a generic label extractor you can set in the middleware configuration.