### PR TITLE
implement Unwrap() for responseWriteInterceptor

### DIFF
--- a/middleware/std/std.go
+++ b/middleware/std/std.go
@@ -87,6 +87,10 @@ func (w *responseWriterInterceptor) Flush() {
 	f.Flush()
 }
 
+func (w *responseWriterInterceptor) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 // Check interface implementations.
 var (
 	_ http.ResponseWriter = &responseWriterInterceptor{}


### PR DESCRIPTION
This change allows to use SetWriteDeadline and SetReadDeadline method of net/http.ResponseController